### PR TITLE
Fix discord sample description

### DIFF
--- a/docs/samples/discord.md
+++ b/docs/samples/discord.md
@@ -1,6 +1,6 @@
 ## Using the Discord sample bundle
 
-The Discord-guild-chat example bundle in `samples/discord-guild-chat` demonstrates the ability ping back messages witch start with `!ping`. Here is a guide to how to get it working.
+The Discord-guild-chat example bundle in `samples/discord-guild-chat` demonstrates the ability to reply with `pong` to messages which are equal to `!ping` or `ping`. Here is a guide to how to get it working.
 
 ### Prerequisites
 


### PR DESCRIPTION
The discord sample description was incorrect because the sample listens on the exact `ping` or `!ping` message and only replies with `pong` and doesn't ping back anything that is followed by the `!ping` message.