### PR TITLE
Specified NodeCG version

### DIFF
--- a/docs/getting_started/install.md
+++ b/docs/getting_started/install.md
@@ -9,7 +9,7 @@ You'll need the following tools:
 -   [Git](https://git-scm.com)
 -   [Node.JS](https://nodejs.org/en/) v12.0.0 or newer
 -   [Npm](https://www.npmjs.com/get-npm)
--   [NodeCG](https://nodecg.dev/)
+-   [NodeCG](https://nodecg.dev/) (legacy-1.x)
 
 You'll also need operating system dependant tools for native modules like Streamdeck and Midi:
 


### PR DESCRIPTION
I specifed the NodeCG version because NodeCG will crash if it's version is 1.3.x or higher. 

### legacy-1.3.x
UNCAUGHT EXCEPTION! NodeCG will now exit.
Error: configuration param 'bundles.paths' not declared in the schema
    at Object.validate (/home/user/workspace/nodecg/node_modules/convict/lib/convict.js:648:17)
    at module.exports (/home/user/workspace/nodecg/lib/config/loader.js:266:16)
    at Object.<anonymous> (/home/user/workspace/nodecg/lib/config/index.js:19:18)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Module.require (internal/modules/cjs/loader.js:952:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at Object.<anonymous> (/home/user/workspace/nodecg/lib/server/index.js:4:22)