### PR TITLE
Add documentation for automatic login

### DIFF
--- a/docs/contribute/contribute.md
+++ b/docs/contribute/contribute.md
@@ -5,12 +5,14 @@ There are many ways to contribute to nodecg-io: logging bugs, submitting pull re
 First you'll need an installation of nodecg-io. Please refer to the [installation guide](../getting_started/install.md) and create a development installation.
 The cli asks you whether you want to clone the documentation. It's highly recommended that you do that and update the documentation as you add new services or features.
 To be able to create Pull Requests you should fork the corresponding repositories and add them as a remote (update url for e.g. documentation repository):
+
 ```shell
 git remote add fork https://github.com/[YOUR_USERNAME]/nodecg-io.git
 ```
 
 Then you can create a new branch, do your changes, create commits and publish the branch to your fork using the following command:
-```
+
+```shell
 git push fork my-branch
 ```
 

--- a/docs/getting_started/configuration.md
+++ b/docs/getting_started/configuration.md
@@ -1,0 +1,41 @@
+# Configuration
+
+<!-- TODO: introduction sentence -->
+
+The configuration file for nodecg-io is at `cfg/nodecg-io-core.json` inside your nodecg installation. This file does not exist by default, you need to create it yourself.
+
+The currently only thing you can configure is automatic login, but there may be more configurable options in the future.
+
+## Automatic login
+
+Automatic login will automatically load nodecg-io when nodecg starts using the provided password.
+
+Therefore nodecg-io will be able to decrypt your configuration for your service instances and provide your bundles with service clients without you logging in to nodecg-io using the dashboard.
+This is especially useful if you are running nodecg with nodecg-io on a server which may reboot from time to time to ensure that your bundles are always working without you needing to manually login after each restart.
+
+**Security warning:** Having both the encrypted configuration and your used password saved on disk defeats nodecg-ios data-at-rest encryption.
+Any program that can read disk contents can access your credentials of any service instance. We discourage using this and if you really want to use it you should be extra cautious about which bundles you install.
+
+Options of automatic login:
+
+- `enabled` (boolean)
+
+  Automatic login will be only enabled if this `enabled` option is set to `true`.
+  This option can be used to temporarily disable automatic login without needing to delete the whole automatic login configuration
+  and allows for easy re-enabling without needing to enter the password in the config again.
+
+- `password` (string)
+
+  This is the password that will be used to login. It should be the password you use to login to nodecg-io.
+  If this password is wrong a error will be logged after startup.
+
+Example config:
+
+```json
+{
+    "automaticLogin": {
+        "enabled": true,
+        "password": "ThisIsMyPassword.PleaseChangeMe"
+    }
+}
+```

--- a/docs/stylesheets/colors.css
+++ b/docs/stylesheets/colors.css
@@ -1,6 +1,6 @@
 :root {
-    --md-primary-fg-color: #5836FF;
-    --md-accent-fg-color: #DD241F;
+    --md-primary-fg-color: #5836ff;
+    --md-accent-fg-color: #dd241f;
     --md-header-color--dark: #2c1849;
 }
 
@@ -13,7 +13,7 @@
 }
 
 .md-nav__source {
-    --md-primary-fg-color--dark: #1F1135;
+    --md-primary-fg-color--dark: #1f1135;
 }
 
 .md-typeset .task-list-control [type="checkbox"]:checked + .task-list-indicator::before {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
     - Getting Started:
           - Installation: getting_started/install.md
           - Your first bundle: getting_started/create_bundle.md
+          - Configuration: getting_started/configuration.md
     - Contribute:
           - Basics: contribute/contribute.md
           - Create a Service: contribute/create_service.md


### PR DESCRIPTION
Explains how automatic login (https://github.com/codeoverflow-org/nodecg-io/pull/241) can be configured.
Also reformats `docs/stylesheets/colors.css`. This was done automatically by prettier from the code repository