### PR TITLE
Update docs and Action workflows for master to main renaming

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,7 +2,7 @@ name: Publish docs via GitHub Pages
 on:
   push:
     branches:
-      - master
+      - main
       - release/**
 
 jobs:
@@ -10,7 +10,7 @@ jobs:
     name: Deploy docs
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout master
+      - name: Checkout main
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
@@ -31,13 +31,13 @@ jobs:
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.${GITHUB_DOMAIN:-github.com}"
 
       - name: Deploy dev docs
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: mike deploy --push --update-aliases DEV
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy release docs
-        if: github.ref != 'refs/heads/master'
+        if: github.ref != 'refs/heads/main'
         run: mike deploy --push --update-aliases ${GITHUB_REF##*/} RELEASE
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/contribute/contribute.md
+++ b/docs/contribute/contribute.md
@@ -88,15 +88,15 @@ official code repo) with your fork.
 
 ```shell
 cd path/to/nodecg-io
-git checkout master
-git pull https://github.com/codeoverflow-org/nodecg-io master
+git checkout main
+git pull https://github.com/codeoverflow-org/nodecg-io main
 ```
 
 Manage any merge conflicts, commit them, and then push them to your fork.
 
-You may also occasionally need to merge upstream master in a pull request. To do
-that make the above to update your local master, and then merge your local
-master into your PR branch.
+You may also occasionally need to merge upstream main in a pull request. To do
+that make the above to update your local main branch, and then merge your local
+main branch into your PR branch.
 
 ### Where to Contribute
 

--- a/docs/contribute/create_service.md
+++ b/docs/contribute/create_service.md
@@ -218,7 +218,7 @@ The file should look like this:
     ## Using the <the services name> sample bundle
 
     No sample bundle for service `<the services name>`.
-    [You can help us and create one!](https://github.com/codeoverflow-org/nodecg-io/blob/master/docs/docs/contribute.md)
+    [You can help us and create one!](https://github.com/codeoverflow-org/nodecg-io-docs/blob/main/docs/contribute/docs_sample.md)
     ```
 
 !!! ATTENTION

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@
 <!-- Do not set the 'Services implemented' value manually. It's inserted automatically. -->
 
 [![Services](https://img.shields.io/static/v1?label=Services%20implemented&message=42&color=blue&style=flat-square)](services.md)
-[![License](https://img.shields.io/github/license/codeoverflow-org/nodecg-io?label=License&style=flat-square)](https://github.com/codeoverflow-org/nodecg-io/blob/master/LICENSE)
+[![License](https://img.shields.io/github/license/codeoverflow-org/nodecg-io?label=License&style=flat-square)](https://github.com/codeoverflow-org/nodecg-io/blob/main/LICENSE)
 [![Discord](https://img.shields.io/badge/discord-join-7289DA.svg?logo=discord&style=flat-square)](https://discord.gg/sX2Gjbs/)
 
 **nodecg-io is a [NodeCG](https://github.com/nodecg/nodecg)-bundle that implements Social Media API's in the NodeCG framework**

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,7 +19,7 @@ site_dir: build
 
 repo_name: codeoverflow-org/nodecg-io
 repo_url: https://github.com/codeoverflow-org/nodecg-io
-edit_uri: https://github.com/codeoverflow-org/nodecg-io-docs/edit/master/docs/
+edit_uri: https://github.com/codeoverflow-org/nodecg-io-docs/edit/main/docs/
 
 markdown_extensions:
     - plantuml_markdown:


### PR DESCRIPTION
Updates references to `master` to `main` in the documentation and in the GitHub Action publis .workflow
Check https://github.com/codeoverflow-org/nodecg-io/issues/266 for more details.

