### PR TITLE
Don't try to publish docs on a dependabot commit

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,11 +4,15 @@ on:
     branches:
       - main
       - release/**
+  schedule:
+    # https://crontab.guru/#3_21_*_*_6
+    - cron: "3 21 * * 6"
 
 jobs:
   build:
     name: Deploy docs
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout main
         uses: actions/checkout@v2


### PR DESCRIPTION
We're having the same problem here as in the main repository.
Commits caused by dependabot updates only have a read access token because of which the push to the `gh-pages` branch failes. To fix this we're doing the same, which is to ignore dependabot commits and run the workflow using a cronjob to still update the changes from dependabot in a timely manner.