### PR TITLE
Use alternative tabbed view and rework migration guide code tabs

### DIFF
--- a/docs/getting_started/existing_bundle.md
+++ b/docs/getting_started/existing_bundle.md
@@ -113,16 +113,14 @@ updated in some way.
 Handlers added with `onAvailable` will get called if there was a change, and you
 got a client:
 
-=== "TypeScript"
-
-    ```typescript
-    // This is the variable with the return value of requireService().
-    // You may want to change the variable name for the service you are using.
-    twitchChat.onAvailable((client) => {
-        nodecg.log.info("Client was set");
-        // You can use the passed client in here to e.g. setup handlers on the client
-    });
-    ```
+```typescript
+// This is the variable with the return value of requireService().
+// You may want to change the variable name for the service you are using.
+twitchChat.onAvailable((client) => {
+    nodecg.log.info("Client was set");
+    // You can use the passed client in here to e.g. setup handlers on the client
+});
+```
 
 `onAvailable` is especially useful to add event handlers to clients. E.g., if
 you want to react to donations or chat messages you can add event handlers for
@@ -132,23 +130,19 @@ Handlers added with `onUnavailable` will get called if the user unassigned your
 bundle from service instance or if there was an error in service client
 creation:
 
-=== "TypeScript"
-
-    ```typescript
-    twitchChat.onUnavailable(() => {
-        nodecg.log.info("Client was unset");
-    });
-    ```
+```typescript
+twitchChat.onUnavailable(() => {
+    nodecg.log.info("Client was unset");
+});
+```
 
 ### Using `getClient`
 
 Instead of callbacks you can also get access to the client directly:
 
-=== "TypeScript"
-
-    ```typescript
-    const twitchChatClient = twitchChat.getClient();
-    ```
+```typescript
+const twitchChatClient = twitchChat.getClient();
+```
 
 `getClient` will return the client if your bundle has an assigned service
 instance that has produced a service client without error and will return

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: nodecg-io Documentation
 site_author: codeoverflow.org
 site_url: https://nodecg.io/
-copyright: "© 2020 codeoverflow.org CC-BY-4.0"
+copyright: "© 2020-2022 codeoverflow.org CC-BY-4.0"
 
 theme:
     palette:
@@ -30,7 +30,8 @@ markdown_extensions:
           pygments_style: monokai
     - pymdownx.inlinehilite
     - pymdownx.superfences
-    - pymdownx.tabbed
+    - pymdownx.tabbed:
+          alternate_style: true
     - pymdownx.tasklist:
           custom_checkbox: true
     - admonition
@@ -106,8 +107,8 @@ nav:
           - Dependency Graph: dependencies.md
 
 extra_css:
-    - stylesheets\colors.css
-    - stylesheets\fonts.css
+    - stylesheets/colors.css
+    - stylesheets/fonts.css
 
 extra:
     version:


### PR DESCRIPTION
mkdocs-material has a new alternative implementation for tabs since
version [7.3.1](https://github.com/squidfunk/mkdocs-material/releases/tag/7.3.1). This PR enables it because it is nice IMHO.

Also removes tabs where language is not important and applies to both
TypeScript and JavaScript in the migration guide.
