### PR TITLE
Bump minimum supported node.js version from 12 to 14.14.0

### DIFF
--- a/docs/getting_started/install.md
+++ b/docs/getting_started/install.md
@@ -10,7 +10,7 @@ need network access.
 You'll need the following tools:
 
 -   [Git](https://git-scm.com)
--   [Node.js](https://nodejs.org/en/) v12.0.0 or newer
+-   [Node.js](https://nodejs.org/en/) v14.14.0 or newer
 -   [npm](https://www.npmjs.com/get-npm) 7.0.0 or newer
 -   [NodeCG](https://nodecg.dev/) 1.4.0 or newer (1.7.0 or higher recommended)
 


### PR DESCRIPTION
See https://github.com/codeoverflow-org/nodecg-io-cli/commit/ff8808a742e4936fe6f4974c151c12b9aa1d6f80.
Since some of our dependencies (like husky) require node.js 14, we need to bump our minimum required node.js version from 12 to 14.
