### PR TITLE
Update stub package.json to not error with NodeCG v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1"
+        "compatibleRange": "*"
     },
     "scripts": {
         "lint": "markdownlint -p .prettierignore .",


### PR DESCRIPTION
NodeCG tries to load the docs repository as a bundle when it is cloned inside the nodecg-io repository as that root path is set as a bundle directory. Because of this we need (and always needed) this stub package.json so NodeCG thinks its a empty bundle and does not crash on startup.

Now that NodeCG v2 is released an error is shown at startup because NodeCG v2 is not included in the range of compatible NodeCG version. This PR updates the range to include any version of NodeCG because nothing is loaded here anyway.
